### PR TITLE
Replace MarketDataManager with MarketDataAggregator

### DIFF
--- a/core/analysis/token_analyzer.py
+++ b/core/analysis/token_analyzer.py
@@ -4,7 +4,7 @@ import logging
 from typing import Dict, Any
 
 from core.storage.database import Database
-from core.data.market_data import MarketDataManager
+from core.data.market_data import MarketDataAggregator
 
 logger = logging.getLogger(__name__)
 
@@ -12,13 +12,13 @@ class TokenAnalyzer:
     """
     Analyzes token data to generate a score and make trading decisions.
     """
-    def __init__(self, db: Database, market_data: MarketDataManager, config):
+    def __init__(self, db: Database, market_data: MarketDataAggregator, config):
         """
         Initializes the TokenAnalyzer.
 
         Args:
             db: The database instance.
-            market_data: The MarketDataManager for fetching on-chain data.
+            market_data: The MarketDataAggregator for fetching on-chain data.
             config: The unified bot configuration object.
         """
         self.db = db

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ from configs.unified_config import Config
 from core.trading.enhanced_trading_bot import EnhancedTradingBot
 from core.blockchain.solana_client import SolanaTrader
 from core.data.token_scanner import TokenScanner
-from core.data.market_data import MarketDataManager
+from core.data.market_data import MarketDataAggregator
 from core.analysis.token_analyzer import TokenAnalyzer
 from core.storage.database import Database
 from core.trading.position_manager import PositionManager
@@ -53,7 +53,7 @@ async def main(mode: str):
         balance_sol, balance_usd = await solana_client.get_wallet_balance()
         logger.info(f"Initial balance: {balance_sol:.4f} SOL (${balance_usd:.2f})")
         
-        market_data = MarketDataManager(CONFIG)
+        market_data = MarketDataAggregator(CONFIG)
         risk_manager = RiskManager(CONFIG, balance_sol)
         position_manager = PositionManager(db, risk_manager, CONFIG)
         token_analyzer = TokenAnalyzer(db, market_data, CONFIG)

--- a/main.py.backup
+++ b/main.py.backup
@@ -16,7 +16,7 @@ from core.trading.position_manager import PositionManager
 from core.trading.risk_manager import RiskManager, TradingParameters
 from core.blockchain.solana_client import SolanaClient
 from core.data.token_scanner import TokenScanner
-from core.data.market_data import MarketDataManager
+from core.data.market_data import MarketDataAggregator
 from core.analysis.token_analyzer import TokenAnalyzer
 from core.storage.database import Database
 from ml.models.ml_predictor import MLPredictor
@@ -62,7 +62,7 @@ async def main(mode: str = 'simulation'):
         logger.info(f"Initial balance: {balance_sol:.4f} SOL (${balance_usd:.2f})")
         
         # Initialize components
-        market_data = MarketDataManager(config)
+        market_data = MarketDataAggregator(config)
         token_analyzer = TokenAnalyzer(db, market_data)
         token_scanner = TokenScanner(db, market_data, token_analyzer)
         ml_predictor = MLPredictor()


### PR DESCRIPTION
## Summary
- update imports in `main.py`, `main.py.backup`, and `token_analyzer`
- use `MarketDataAggregator` instead of `MarketDataManager`
- adjust type hints and docs

## Testing
- `python -m py_compile main.py main.py.backup core/analysis/token_analyzer.py`

------
https://chatgpt.com/codex/tasks/task_e_684b3b7cc244832d8440195c159b4986